### PR TITLE
Move to latest branch versioning

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -3,13 +3,6 @@ on:
   push:
     branches: [master]
 jobs:
-  git:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Bump latest tag
-        uses: EndBug/latest-tag@v1
   docker:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
* Disable `latest` tag creation given that the `latest` branch points at the `latest` Docker tag, which should suffice for now.
* See https://github.com/namoscato/action-tinify/issues/38 for some more context, i.e. we could wire up some automation that keeps the `latest` branch in sync with `master` at some point
